### PR TITLE
Clear imageUrl and imageCaption on modal close

### DIFF
--- a/src/lightbox-service.js
+++ b/src/lightbox-service.js
@@ -156,6 +156,8 @@ angular.module('bootstrapLightbox').provider('Lightbox', function () {
         // prevent the lightbox from flickering from the old image when it gets
         // opened again
         Lightbox.image = {};
+        Lightbox.imageUrl = null;
+        Lightbox.imageCaption = null;
 
         Lightbox.keyboardNavEnabled = false;
 


### PR DESCRIPTION
Resetting Lightbox.image is not enough to prevent flickering in Firefox (32). 
