### PR TITLE
Custom params for UI Bootstrap $modal.open

### DIFF
--- a/src/lightbox-service.js
+++ b/src/lightbox-service.js
@@ -243,17 +243,19 @@ angular.module('bootstrapLightbox').provider('Lightbox', function () {
      *   any type.
      * @param    {Number} newIndex  The index in `newImages` to set as the
      *   current image.
+     * @param    {Object} modalParams  Custom params for the angular UI
+     *   bootstrap modal (in $modal.open()).
      * @return   {Object} The created UI Bootstrap modal instance.
      * @type     {Function}
      * @name     openModal
      * @memberOf bootstrapLightbox.Lightbox
      */
-    Lightbox.openModal = function (newImages, newIndex) {
+    Lightbox.openModal = function (newImages, newIndex, modalParams) {
       Lightbox.images = newImages;
       Lightbox.setImage(newIndex);
 
       // store the modal instance so we can close it manually if we need to
-      Lightbox.modalInstance = $modal.open({
+      Lightbox.modalInstance = $modal.open(angular.extend({
         'templateUrl': Lightbox.templateUrl,
         'controller': ['$scope', function ($scope) {
           // $scope is the modal scope, a child of $rootScope
@@ -262,7 +264,7 @@ angular.module('bootstrapLightbox').provider('Lightbox', function () {
           Lightbox.keyboardNavEnabled = true;
         }],
         'windowClass': 'lightbox-modal'
-      });
+      }, modalParams || {}));
 
       // modal close handler
       Lightbox.modalInstance.result['finally'](function () {


### PR DESCRIPTION
**Description**
In the lightbox-service, the method _Lightbox.openModal_ makes a call to _$modal.open_ with some parameters.

I needed to be able to add other _supported_ parameters for _$modal.open_ ("size": "lg", for example).

This pull request adds a third parameter in the _Lightbox.openModal_ method, so it's possible to inject other configuration params to _$modal.open_.

**Usage**
```javascript
var images = [ /* list of images */ ];
    index = 1,
    // UI Bootstrap modal configuration
    modalConfig = {
        size: 'lg'
    };

Lightbox.openModal(images, index, modalConfig);
```