### PR TITLE
Add index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-bootstrap-lightbox');
+module.exports = 'angular-bootstrap-lightbox';


### PR DESCRIPTION
This PR adds `index.js`, allowing angular-bootstrap-lightbox to be imported via [`require()`](http://www.bennadel.com/blog/2169-where-does-node-js-and-require-look-for-modules.htm). Without this, node (via webpack, and likely other bundlers) fails to locate the `dist/angular-bootstrap-lightbox.js` file and throws a `Module not found: Error: Cannot resolve module 'angular-bootstrap-lightbox'` error.