### PR TITLE
fixed module name for componentjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 require('./dist/angular-bootstrap-lightbox');
-module.exports = 'angular-bootstrap-lightbox';
+module.exports = 'bootstrapLightbox';


### PR DESCRIPTION
The only way I could get this to work properly was to fix the module name to match the angular module name, this is how it's done in other modules as well.
