### PR TITLE
Add catch to rejected promise.

### DIFF
--- a/dist/angular-bootstrap-lightbox.js
+++ b/dist/angular-bootstrap-lightbox.js
@@ -340,7 +340,7 @@ angular.module('bootstrapLightbox').provider('Lightbox', function () {
       }, modalParams || {}));
 
       // modal close handler
-      Lightbox.modalInstance.result['finally'](function () {
+      Lightbox.modalInstance.result.finally(function () {
         // prevent the lightbox from flickering from the old image when it gets
         // opened again
         Lightbox.images = [];
@@ -355,7 +355,7 @@ angular.module('bootstrapLightbox').provider('Lightbox', function () {
         if (cfpLoadingBar) {
           cfpLoadingBar.complete();
         }
-      });
+      }).then(function() {}, function() {});
 
       return Lightbox.modalInstance;
     };


### PR DESCRIPTION
Silence exceptions of type "Possible unhandled rejection" (with angularjs 1.6) when the lightbox modal gets dismissed.